### PR TITLE
Recipe Fix

### DIFF
--- a/src/main/resources/data/bhc/recipes/blue_heart.json
+++ b/src/main/resources/data/bhc/recipes/blue_heart.json
@@ -10,7 +10,7 @@
       "item": "bhc:blue_heart_melted"
     },
     "H": {
-      "tag": "forge:heart"
+      "tag": "bhc:heart"
     }
   },
   "result": {

--- a/src/main/resources/data/bhc/recipes/blue_heart_canister.json
+++ b/src/main/resources/data/bhc/recipes/blue_heart_canister.json
@@ -11,7 +11,7 @@
       "item": "minecraft:netherite_block"
     },
     {
-      "tag": "forge:gems/emerald"
+      "item": "minecraft:emerald"
     }
   ],
   "result": {

--- a/src/main/resources/data/bhc/recipes/blue_heart_patch.json
+++ b/src/main/resources/data/bhc/recipes/blue_heart_patch.json
@@ -10,7 +10,7 @@
       "tag": "minecraft:wool"
     },
     "S": {
-      "tag": "forge:string"
+      "item": "minecraft:string"
     },
     "H": {
       "item": "bhc:blue_heart"

--- a/src/main/resources/data/bhc/recipes/god_apple.json
+++ b/src/main/resources/data/bhc/recipes/god_apple.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "G": {
-      "tag": "forge:storage_blocks/gold"
+      "item": "minecraft:gold_block"
     },
     "A": {
       "item": "minecraft:apple"

--- a/src/main/resources/data/bhc/recipes/green_heart.json
+++ b/src/main/resources/data/bhc/recipes/green_heart.json
@@ -10,7 +10,7 @@
       "item": "bhc:green_heart_melted"
     },
     "H": {
-      "tag": "forge:heart"
+      "tag": "bhc:heart"
     }
   },
   "result": {

--- a/src/main/resources/data/bhc/recipes/green_heart_canister.json
+++ b/src/main/resources/data/bhc/recipes/green_heart_canister.json
@@ -8,7 +8,7 @@
       "item": "bhc:yellow_heart_canister"
     },
     {
-      "tag": "forge:nether_stars"
+      "item": "minecraft:nether_star"
     },
     {
       "item": "minecraft:shulker_shell"

--- a/src/main/resources/data/bhc/recipes/green_heart_patch.json
+++ b/src/main/resources/data/bhc/recipes/green_heart_patch.json
@@ -10,7 +10,7 @@
       "tag": "minecraft:wool"
     },
     "S": {
-      "tag": "forge:string"
+      "item": "minecraft:string"
     },
     "H": {
       "item": "bhc:green_heart"

--- a/src/main/resources/data/bhc/recipes/red_heart.json
+++ b/src/main/resources/data/bhc/recipes/red_heart.json
@@ -10,7 +10,7 @@
       "item": "bhc:red_heart_melted"
     },
     "H": {
-      "tag": "forge:heart"
+      "tag": "bhc:heart"
     }
   },
   "result": {

--- a/src/main/resources/data/bhc/recipes/red_heart_canister.json
+++ b/src/main/resources/data/bhc/recipes/red_heart_canister.json
@@ -5,7 +5,7 @@
       "item": "bhc:red_heart"
     },
     {
-      "tag": "forge:wither_bones"
+      "item": "bhc:wither_bone"
     },
     {
       "item": "bhc:relic_apple"

--- a/src/main/resources/data/bhc/recipes/red_heart_patch.json
+++ b/src/main/resources/data/bhc/recipes/red_heart_patch.json
@@ -10,7 +10,7 @@
       "tag": "minecraft:wool"
     },
     "S": {
-      "tag": "forge:string"
+      "item": "minecraft:string"
     },
     "H": {
       "item": "bhc:red_heart"

--- a/src/main/resources/data/bhc/recipes/smithing/soul_heart_canister.json
+++ b/src/main/resources/data/bhc/recipes/smithing/soul_heart_canister.json
@@ -10,6 +10,6 @@
     "item": "bhc:soul_heart_canister"
   },
   "template": {
-    "tag": "forge:heart"
+    "tag": "bhc:heart"
   }
 }

--- a/src/main/resources/data/bhc/recipes/yellow_heart.json
+++ b/src/main/resources/data/bhc/recipes/yellow_heart.json
@@ -10,7 +10,7 @@
       "item": "bhc:yellow_heart_melted"
     },
     "H": {
-      "tag": "forge:heart"
+      "tag": "bhc:heart"
     }
   },
   "result": {

--- a/src/main/resources/data/bhc/recipes/yellow_heart_patch.json
+++ b/src/main/resources/data/bhc/recipes/yellow_heart_patch.json
@@ -10,7 +10,7 @@
       "tag": "minecraft:wool"
     },
     "S": {
-      "tag": "forge:string"
+      "item": "minecraft:string"
     },
     "H": {
       "item": "bhc:yellow_heart"


### PR DESCRIPTION
Some of the recipes didn't work because they were relying on forge. This commit switches items to bhc: or minecraft: where appropriate.