### PR TITLE
[1.20.1] Make use of Wither Bones tag for Red Heart Canister recipe

### DIFF
--- a/src/main/resources/data/bhc/recipes/red_heart_canister.json
+++ b/src/main/resources/data/bhc/recipes/red_heart_canister.json
@@ -5,7 +5,7 @@
       "item": "bhc:red_heart"
     },
     {
-      "item": "bhc:wither_bone"
+      "tag": "c:wither_bones"
     },
     {
       "item": "bhc:relic_apple"

--- a/src/main/resources/data/c/tags/items/wither_bones.json
+++ b/src/main/resources/data/c/tags/items/wither_bones.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "bhc:wither_bone"
+  ]
+}


### PR DESCRIPTION
Hephaestus / Tinkers' Construct makes use of the `#c:wither_bones` tag as well.

Fixes #4.